### PR TITLE
Allow String Audio Ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sourcemap.json

--- a/demo/ReplicatedStorage/Data/Audio.lua
+++ b/demo/ReplicatedStorage/Data/Audio.lua
@@ -25,7 +25,7 @@ return {
                 },
             },
             LocalLooped = {
-                Id = 12222253,
+                Id = "rbxassetid://12222253",
                 Length = 1.207,
                 Events = {
                     {
@@ -43,7 +43,7 @@ return {
                 },
             },
             Global = {
-                Id = 12221967,
+                Id = "rbxasset://sounds/volume_slider.ogg",
                 Length = 0.293,
                 Properties = {
                     Volume = 0.2,

--- a/src/ClientSound.lua
+++ b/src/ClientSound.lua
@@ -41,9 +41,13 @@ function ClientSound.new(Id: string, ReplicationValue: StringValue, Parent: Inst
     self.SoundData = SoundData
 
     --Create the sound.
+    local SoundId = SoundData.Id
+    if typeof(SoundId) ~= "string" then
+        SoundId = "rbxassetid://"..tostring(SoundId)
+    end
     local Sound = Instance.new("Sound")
     Sound.Name = string.gsub(Id, "%.", "")
-    Sound.SoundId = "rbxassetid://"..tostring(SoundData.Id)
+    Sound.SoundId = SoundId
     for Key, Value in pairs(SoundData.Properties or {}) do
         Sound[Key] = Value
     end

--- a/src/ClientSound.lua
+++ b/src/ClientSound.lua
@@ -64,7 +64,7 @@ function ClientSound.new(Id: string, ReplicationValue: StringValue, Parent: Inst
     end)
 
     --Return the object.
-    return self
+    return self :: any
 end
 
 --[[

--- a/src/LocalAudioTypes.lua
+++ b/src/LocalAudioTypes.lua
@@ -27,17 +27,17 @@ export type SoundDataEntry = {
 
 --Classes
 export type SoundState = {
-    Save: (SoundState) -> nil,
-    Play: (SoundState) -> nil,
-    Resume: (SoundState) -> nil,
-    Pause: (SoundState) -> nil,
-    Stop: (SoundState) -> nil,
-    SetEffects: (SoundState, {[string]: {[string]: any}}) -> nil,
+    Save: (SoundState) -> (),
+    Play: (SoundState) -> (),
+    Resume: (SoundState) -> (),
+    Pause: (SoundState) -> (),
+    Stop: (SoundState) -> (),
+    SetEffects: (SoundState, {[string]: {[string]: any}}) -> (),
     StateValue: StringValue,
 }
 
 export type ClientSound = {
-    Update: (ClientSound) -> nil,
+    Update: (ClientSound) -> (),
 }
 
 

--- a/src/LocalAudioTypes.lua
+++ b/src/LocalAudioTypes.lua
@@ -17,7 +17,7 @@ export type SoundDataEntryEvent = {
 }
 
 export type SoundDataEntry = {
-    Id: number,
+    Id: number | string,
     Length: number,
     Properties: {[string]: any}?,
     Effects: {[string]: {[string]: any}}?,

--- a/src/SoundState.lua
+++ b/src/SoundState.lua
@@ -87,13 +87,13 @@ function SoundState.new(Id: string, Parent: Instance?): LocalAudioTypes.SoundSta
     StateValue.Parent = ValueParent
 
     --Return the object.
-    return self
+    return self :: any
 end
 
 --[[
 Saves the state.
 --]]
-function SoundState:Save(): nil
+function SoundState:Save(): ()
     --Save the state.
     local LastSaveTime = tick()
     self.StateValue.Value = HttpService:JSONEncode(self.State)
@@ -113,7 +113,7 @@ end
 --[[
 Plays the audio.
 --]]
-function SoundState:Play(): nil
+function SoundState:Play(): ()
     self.State.State = "Play"
     self.State.StartTime = Workspace:GetServerTimeNow() - ((self.SoundData.Properties and self.SoundData.Properties.TimePosition) or 0)
     self.PauseElapsedTime = nil
@@ -123,7 +123,7 @@ end
 --[[
 Resumes the audio.
 --]]
-function SoundState:Resume(): nil
+function SoundState:Resume(): ()
     if self.State.State == "Play" then return end
     self.State.State = "Play"
     self.State.StartTime = Workspace:GetServerTimeNow() - (self.PauseElapsedTime or 0)
@@ -134,7 +134,7 @@ end
 --[[
 Pauses the audio.
 --]]
-function SoundState:Pause(): nil
+function SoundState:Pause(): ()
     if self.State.State == "Stop" then return end
     self.State.State = "Stop"
     self.PauseElapsedTime = (Workspace:GetServerTimeNow() - self.State.StartTime) % self.SoundData.Length
@@ -144,7 +144,7 @@ end
 --[[
 Stops the audio.
 --]]
-function SoundState:Stop(): nil
+function SoundState:Stop(): ()
     if self.State.State == "Stop" then return end
     self.State.State = "Stop"
     self:Save()
@@ -154,7 +154,7 @@ end
 --[[
 Sets the effects of the audio.
 --]]
-function SoundState:SetEffects(Effects: {[string]: {[string]: any}}): nil
+function SoundState:SetEffects(Effects: {[string]: {[string]: any}}): ()
     self.State.Effects = Effects
     self:Save()
 end

--- a/src/init.lua
+++ b/src/init.lua
@@ -97,7 +97,10 @@ function LocalAudio:PreloadAudio(Id: string): ()
         PreloadAudioEvent:FireAllClients(Id)
     else
         --Preload the audio.
-        local SoundId = "rbxassetid://"..tostring(SoundState.GetSoundData(Id).Id)
+        local SoundId = SoundState.GetSoundData(Id).Id
+        if typeof(SoundId) ~= "string" then
+            SoundId = "rbxassetid://"..tostring(SoundId)
+        end
         if self.PreloadedAudios[SoundId] then return end
         self.PreloadedAudios[SoundId] = true
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -66,7 +66,7 @@ end
 --[[
 Connects a parent of values.
 --]]
-local function ConnectParent(Parent: Instance): nil
+local function ConnectParent(Parent: Instance): ()
     --Wait for the instance to exist.
     if Parent:IsA("ObjectValue") then
         while not Parent.Value do
@@ -91,7 +91,7 @@ end
 --[[
 Preloads an audio on the client.
 --]]
-function LocalAudio:PreloadAudio(Id: string): nil
+function LocalAudio:PreloadAudio(Id: string): ()
     if RunService:IsServer() then
         --Tell the clients to preload the audio.
         PreloadAudioEvent:FireAllClients(Id)
@@ -136,7 +136,7 @@ end
 --[[
 Opens a slot for the given audio id to be played. Does nothing if there are no limits.
 --]]
-function LocalAudio:OpenSlot(Id: string, LeaveAtLimit: boolean?): nil
+function LocalAudio:OpenSlot(Id: string, LeaveAtLimit: boolean?): ()
     for Group, Limit in pairs(AudioData.MaxConcurrentTracks or {}) do
         if not IsInGroup(Id, Group) then continue end
         local SoundValues = self:GetValuesInGroup(Group)
@@ -154,7 +154,7 @@ end
 --[[
 Plays an audio on the client.
 --]]
-function LocalAudio:PlayAudio(Id: string, Parent: Instance?): nil
+function LocalAudio:PlayAudio(Id: string, Parent: Instance?): ()
     --Return if the audio is not able to open a slot.
     local SoundData = SoundState.GetSoundData(Id)
     if SoundData.LowPriority and not self:HasOpenSlot(Id) then
@@ -169,7 +169,7 @@ end
 --[[
 Reumes an audio on the client.
 --]]
-function LocalAudio:ResumeAudio(Id: string, Parent: Instance?): nil
+function LocalAudio:ResumeAudio(Id: string, Parent: Instance?): ()
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in pairs(ValueContainer:GetChildren()) do
         local StateObject = self.ValuesToStateObjects[SoundValue]
@@ -183,7 +183,7 @@ end
 --[[
 Pauses an audio on the client.
 --]]
-function LocalAudio:PauseAudio(Id: string, Parent: Instance?): nil
+function LocalAudio:PauseAudio(Id: string, Parent: Instance?): ()
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in pairs(ValueContainer:GetChildren()) do
         local StateObject = self.ValuesToStateObjects[SoundValue]
@@ -197,7 +197,7 @@ end
 --[[
 Stops an audio on the client.
 --]]
-function LocalAudio:StopAudio(Id: string, Parent: Instance?): nil
+function LocalAudio:StopAudio(Id: string, Parent: Instance?): ()
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in pairs(ValueContainer:GetChildren()) do
         if SoundValue.Name ~= Id then continue end
@@ -212,7 +212,7 @@ end
 --[[
 Sets the effects for a sound.
 --]]
-function LocalAudio:SetEffects(Id: string, Parent: Instance?, Effects: {[string]: {[string]: any}}): nil
+function LocalAudio:SetEffects(Id: string, Parent: Instance?, Effects: {[string]: {[string]: any}}): ()
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in pairs(ValueContainer:GetChildren()) do
         local StateObject = self.ValuesToStateObjects[SoundValue]
@@ -235,7 +235,7 @@ end
 --[[
 Sets up the sounds on the client.
 --]]
-function LocalAudio:SetUp(): nil
+function LocalAudio:SetUp(): ()
     --Connect preloading audios.
     PreloadAudioEvent.OnClientEvent:Connect(function(Id: string)
         self:PreloadAudio(Id)


### PR DESCRIPTION
Audios ids that are stored as strings (mainly `rbxasset://` as opposed to `rbxassetid://`) don't work because `rbxassetid://` is always pre-pended to the id. This pull request adds this check to allow string-based ids. Other issues with typing have also been addressed.