### PR TITLE
Add Sound Tagging

### DIFF
--- a/demo/ReplicatedStorage/Data/Audio.lua
+++ b/demo/ReplicatedStorage/Data/Audio.lua
@@ -23,6 +23,9 @@ return {
                         Name = "CheerSecond",
                     },
                 },
+                Tags = {
+                    "TestTag",
+                },
             },
             LocalLooped = {
                 Id = "rbxassetid://12222253",

--- a/demo/StarterPlayerScripts/LocalAudioSetup.client.lua
+++ b/demo/StarterPlayerScripts/LocalAudioSetup.client.lua
@@ -19,3 +19,7 @@ end)
 LocalAudio:OnEventFired("CheerStart"):Connect(function(_, _, Parent, Sound)
     print("Cheer sound started on "..tostring(Parent).." in "..tostring(Sound))
 end)
+
+game:GetService("CollectionService"):GetInstanceAddedSignal("TestTag"):Connect(function(Sound)
+    print("Sound tagged: "..Sound:GetFullName())
+end)

--- a/src/ClientSound.lua
+++ b/src/ClientSound.lua
@@ -6,6 +6,7 @@ Instance of a sound on the client.
 
 local Workspace = game:GetService("Workspace")
 local SoundService = game:GetService("SoundService")
+local CollectionService = game:GetService("CollectionService")
 local HttpService = game:GetService("HttpService")
 
 local AudioData = require(script.Parent:WaitForChild("AudioData"))
@@ -52,6 +53,9 @@ function ClientSound.new(Id: string, ReplicationValue: StringValue, Parent: Inst
         Sound[Key] = Value
     end
     Sound.Parent = Parent or SoundService
+    for _, Tag in SoundData.Tags or {} do
+        CollectionService:AddTag(Sound, Tag)
+    end
     self.Sound = Sound
 
     --Connect the value changing.


### PR DESCRIPTION
This small pull request adds tags to the `Sound` instances. It allows for external management of the sounds, such as dynamically applying effects or assigning `SoundGroup`s.