### PR TITLE
Fix loop making too many instances

### DIFF
--- a/demo/ServerScriptService/LocalSoundsTest.server.lua
+++ b/demo/ServerScriptService/LocalSoundsTest.server.lua
@@ -22,6 +22,7 @@ LocalAudio:PlayAudio("Demo.LocalLooped", TestModels:WaitForChild("Part5"))
 while true do
     for _, TestPart in pairs(TestParts) do
         LocalAudio:PlayAudio("Demo.Local", TestPart)
-        task.wait(1)
+        task.wait(1.2)
+        LocalAudio:StopAudio("Demo.Local", TestPart)
     end
 end

--- a/demo/ServerScriptService/LocalSoundsTest.server.lua
+++ b/demo/ServerScriptService/LocalSoundsTest.server.lua
@@ -22,7 +22,6 @@ LocalAudio:PlayAudio("Demo.LocalLooped", TestModels:WaitForChild("Part5"))
 while true do
     for _, TestPart in pairs(TestParts) do
         LocalAudio:PlayAudio("Demo.Local", TestPart)
-        task.wait(1.2)
-        LocalAudio:StopAudio("Demo.Local", TestPart)
+        task.wait(1)
     end
 end

--- a/src/ClientSound.lua
+++ b/src/ClientSound.lua
@@ -65,8 +65,7 @@ function ClientSound.new(Id: string, ReplicationValue: StringValue, Parent: Inst
     self:Update()
 
     --Connect the value being destroyed (stopped).
-    ReplicationValue:GetPropertyChangedSignal("Parent"):Connect(function()
-        if ReplicationValue.Parent then return end
+    ReplicationValue.Destroying:Connect(function()
         self.Sound:Stop()
         self.Sound:Destroy()
     end)


### PR DESCRIPTION
When testing, I noticed that the loop created a new sound instance each time it played the audio. This slowly causes memory usage to rise, stopping the audio fixes this as the sound instance gets destroyed then. Perhaps there should be a check if the same sound is already playing on the same parent?