### PR TITLE
Fix SoundState Memory Leak

### DIFF
--- a/src/SoundState.luau
+++ b/src/SoundState.luau
@@ -9,6 +9,7 @@ local LocalAudioTypes = require(script.Parent:WaitForChild("LocalAudioTypes"))
 
 local SoundState = {}
 SoundState.AutomaticClearDelay = 3 --An additional delay is added to clearing audios to mitigate audios cutting out on the client.
+SoundState.ActiveSoundStates = {}
 SoundState.__index = SoundState
 
 local CurrentAudioFolder = script.Parent:WaitForChild("CurrentAudio")
@@ -92,6 +93,7 @@ function SoundState.new(Id: string, Parent: Instance?): SoundState
     local StateValue = Instance.new("StringValue")
     StateValue.Name = Id
     self.StateValue = StateValue
+    self.ActiveSoundStates[StateValue] = self
     self:Play()
     StateValue.Parent = ValueParent
 
@@ -104,7 +106,7 @@ function SoundState.new(Id: string, Parent: Instance?): SoundState
     end
 
     --Return the object.
-    return self :: any
+    return self
 end
 
 --[[
@@ -171,6 +173,7 @@ function SoundState.Stop(self: SoundState): ()
         EventConnection:Disconnect()
     end
     self.EventConnections = {}
+    self.ActiveSoundStates[self.StateValue] = nil
 end
 
 --[[

--- a/src/init.luau
+++ b/src/init.luau
@@ -9,8 +9,6 @@ local LocalAudioTypes = require(script:WaitForChild("LocalAudioTypes"))
 
 local LocalAudio = {}
 LocalAudio.PreloadedAudios = {}
-LocalAudio.ValuesToStateObjects = {}
-setmetatable(LocalAudio.ValuesToStateObjects, {__mode="k"})
 
 export type LocalAudio = typeof(LocalAudio)
 
@@ -148,8 +146,8 @@ function LocalAudio.OpenSlot(self: LocalAudio, Id: string, LeaveAtLimit: boolean
         local SoundValues = self:GetValuesInGroup(Group)
         while #SoundValues >= (LeaveAtLimit and Limit + 1 or Limit) do
             local SoundValue = SoundValues[1]
-            if self.ValuesToStateObjects[SoundValue] then
-                self.ValuesToStateObjects[SoundValue]:Stop()
+            if SoundState.ActiveSoundStates[SoundValue] then
+                SoundState.ActiveSoundStates[SoundValue]:Stop()
             end
             SoundValue:Destroy()
             table.remove(SoundValues, 1)
@@ -168,8 +166,7 @@ function LocalAudio.PlayAudio(self: LocalAudio,Id: string, Parent: Instance?): (
     end
 
     --Play the new audio.
-    local Sound = SoundState.new(Id, Parent)
-    self.ValuesToStateObjects[Sound.StateValue] = Sound
+    SoundState.new(Id, Parent)
 end
 
 --[[
@@ -179,7 +176,7 @@ function LocalAudio.ResumeAudio(self: LocalAudio,Id: string, Parent: Instance?):
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in ValueContainer:GetChildren() do
         if not SoundValue:IsA("StringValue") then continue end
-        local StateObject = self.ValuesToStateObjects[SoundValue]
+        local StateObject = SoundState.ActiveSoundStates[SoundValue]
         if SoundValue.Name ~= Id then continue end
         if not StateObject or StateObject.State.State ~= "Stop" then continue end
         StateObject:Resume()
@@ -194,7 +191,7 @@ function LocalAudio.PauseAudio(self: LocalAudio,Id: string, Parent: Instance?): 
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in ValueContainer:GetChildren() do
         if not SoundValue:IsA("StringValue") then continue end
-        local StateObject = self.ValuesToStateObjects[SoundValue]
+        local StateObject = SoundState.ActiveSoundStates[SoundValue]
         if SoundValue.Name ~= Id then continue end
         if not StateObject or StateObject.State.State ~= "Play" then continue end
         StateObject:Pause()
@@ -210,8 +207,8 @@ function LocalAudio.StopAudio(self: LocalAudio,Id: string, Parent: Instance?): (
     for _, SoundValue in ValueContainer:GetChildren() do
         if not SoundValue:IsA("StringValue") then continue end
         if SoundValue.Name ~= Id then continue end
-        if self.ValuesToStateObjects[SoundValue] then
-            self.ValuesToStateObjects[SoundValue]:Stop()
+        if SoundState.ActiveSoundStates[SoundValue] then
+            SoundState.ActiveSoundStates[SoundValue]:Stop()
         end
         SoundValue:Destroy()
         break
@@ -225,7 +222,7 @@ function LocalAudio.SetEffects(self: LocalAudio,Id: string, Parent: Instance?, E
     local ValueContainer = SoundState.GetValueContainer(Parent)
     for _, SoundValue in ValueContainer:GetChildren() do
         if not SoundValue:IsA("StringValue") then continue end
-        local StateObject = self.ValuesToStateObjects[SoundValue]
+        local StateObject = SoundState.ActiveSoundStates[SoundValue]
         if SoundValue.Name ~= Id then continue end
         if not StateObject or StateObject.State.State ~= "Play" then continue end
         StateObject:SetEffects(Effects)


### PR DESCRIPTION
`SoundState`s currently appear to cause a memory leak due to never being cleared. Instead of relying on a weak table that doesn't seem to work, `SoundState`s are now properly managed.